### PR TITLE
GCProfile charts (used for the paper)

### DIFF
--- a/src/GCProfile/GCChart.class.st
+++ b/src/GCProfile/GCChart.class.st
@@ -1,0 +1,91 @@
+Class {
+	#name : #GCChart,
+	#superclass : #Object,
+	#category : #GCProfile
+}
+
+{ #category : #factory }
+GCChart class >> multi [
+
+	^ GCPMultiChart new
+]
+
+{ #category : #factory }
+GCChart class >> simple [
+
+	^ GCPSimpleChart new
+]
+
+{ #category : #plot }
+GCChart >> addLegend: legend toChart: chart [
+
+	legend container: chart canvas.
+	legend legendDo: [ :shape | shape scaleBy: 0.6 ].
+	legend layout vertical.
+	legend location
+		outer;
+		right;
+		offset: 210 @ -200.
+	legend build
+]
+
+{ #category : #plot }
+GCChart >> addTicks: nTicks toChart: chart [
+
+	| fontSize |
+	fontSize := 7.
+
+	chart addDecoration: (RSHorizontalTick new
+			 numberOfTicks: nTicks;
+			 fontSize: fontSize;
+			 labelConversion: [ :e | e asInteger printString ];
+			 yourself).
+	chart addDecoration: (RSVerticalTick new
+			 numberOfTicks: nTicks;
+			 fontSize: fontSize;
+			 labelConversion: [ :e | e asInteger printString ];
+			 yourself)
+]
+
+{ #category : #private }
+GCChart >> loadGCLogFrom: fileReference [
+
+	| lines |
+	lines := '---' split: fileReference contents.
+	^ lines allButLast collect: [ :ston | STON fromString: ston ]
+]
+
+{ #category : #plot }
+GCChart >> multiPlotWith: plots [
+
+	| c shapes |
+	c := RSCanvas new.
+
+	shapes := plots collect: [ :plot |
+		          | shape |
+		          c add: (shape := plot asShape).
+		          shape ].
+
+	(RSGridLayout withGap: 30) on: shapes.
+	c @ RSCanvasController.
+	^ c
+]
+
+{ #category : #'as yet unclassified' }
+GCChart >> plotAllScavengesIn: logFiles [
+
+	| c shapes |
+	c := RSCanvas new.
+	
+	shapes := logFiles collect: [ :f |
+		          | trace plotName plot shape |
+		          trace := self loadGCLogFrom: f.
+		          plotName := f path segments last.
+		          plot := self plotScavenge: { plotName } , trace.
+		          c add: (shape := plot asShape).
+		          shape ].
+
+	RSGridLayout on: shapes.
+	c @ RSCanvasController.
+	^ c
+]

--- a/src/GCProfile/GCPMultiChart.class.st
+++ b/src/GCProfile/GCPMultiChart.class.st
@@ -1,0 +1,250 @@
+Class {
+	#name : #GCPMultiChart,
+	#superclass : #GCChart,
+	#instVars : [
+		'profiles'
+	],
+	#category : #GCProfile
+}
+
+{ #category : #configure }
+GCPMultiChart >> addProfile: edenSizesWithFiles forApplication: name [
+
+	profiles at: name put: edenSizesWithFiles
+]
+
+{ #category : #initialization }
+GCPMultiChart >> initialize [
+
+	super initialize.
+	profiles := OrderedDictionary new
+]
+
+{ #category : #plot }
+GCPMultiChart >> multiPlot: selectors [
+
+	| c shapes |
+	c := RSCanvas new.
+
+	shapes := selectors collect: [ :s |
+		          | plot shape |
+		          plot := self perform: s.
+		          c add: (shape := plot asShape).
+		          shape ].
+
+	(RSGridLayout
+		withGap: 30)
+		on: shapes.
+	c @ RSCanvasController.
+	^ c
+]
+
+{ #category : #plot }
+GCPMultiChart >> plotGCPasses [
+
+	| chart legend |
+	chart := RSChart new.
+	legend := RSLegend new.
+
+	profiles associations sorted do: [ :tuple |	| name edenSizesWithFiles data plot |
+		name := tuple key.
+		edenSizesWithFiles := tuple value.
+		data := edenSizesWithFiles sorted asOrderedDictionary collect: [ :file |
+			        | trace |
+			        trace := self loadGCLogFrom: file.
+			        trace size ].
+		chart
+			addPlot: (plot := RSLinePlot new x: data keys y: data values);
+			addPlot: (RSScatterPlot new x: data keys y: data values).
+
+		legend text: name withBoxColor: plot computeColor ].
+
+	self addTicks: 5 toChart: chart.
+			
+	self addLegend: legend toChart: chart.
+
+
+	chart xlabel: 'Eden size [MB]'.
+	chart ylabel: 'Number of GC passes'.
+	chart title: 'Number of Scavenges and FullGC based on Eden size'.
+	^ chart
+]
+
+{ #category : #plot }
+GCPMultiChart >> plotGCRatio [
+
+	| chart legend data plot |
+	chart := RSChart new.
+	legend := RSLegend new.
+
+
+	self profilesDo: [ :name :ratiosWithFiles |
+		data := ratiosWithFiles sorted asOrderedDictionary collect: [ :file |
+			        | trace fullGCs |
+			        trace := self loadGCLogFrom: file.
+			        fullGCs := trace select: [ :e |
+				                   e className includesSubstring: 'FullGC' ].
+			        fullGCs size ].
+
+		chart
+			addPlot: (plot := RSLinePlot new x: data keys y: data values);
+			addPlot: (RSScatterPlot new x: data keys y: data values).
+
+		legend text: name withBoxColor: plot computeColor ].
+
+	self addTicks: 5 toChart: chart.
+
+
+	legend container: chart canvas.
+	legend legendDo: [ :shape | shape scaleBy: 0.6 ].
+	legend layout vertical.
+	legend location
+		outer;
+		right;
+		offset: 210 @ -200.
+	legend build.
+
+
+	chart xlabel: 'FullGC ratio [% of memory]'.
+	chart ylabel: 'Number of FullGC passes'.
+	chart title: 'FullGC passes based on FullGC ratio threshold'.
+	^ chart
+]
+
+{ #category : #plot }
+GCPMultiChart >> plotHeadroom [
+
+		| chart legend data plot |
+	chart := RSChart new.
+	legend := RSLegend new.
+
+
+	self profilesDo: [ :name :ratiosWithFiles |
+		data := ratiosWithFiles sorted asOrderedDictionary collect: [ :file |
+			        | trace fullGCs |
+			        trace := self loadGCLogFrom: file.
+			        fullGCs := trace select: [ :e |
+				                   e className includesSubstring: 'FullGC' ].
+			        fullGCs size ].
+
+		chart
+			addPlot: (plot := RSLinePlot new x: data keys y: data values);
+			addPlot: (RSScatterPlot new x: data keys y: data values).
+
+		legend text: name withBoxColor: plot computeColor ].
+
+	self addTicks: 5 toChart: chart.
+
+
+	legend container: chart canvas.
+	legend legendDo: [ :shape | shape scaleBy: 0.6 ].
+	legend layout vertical.
+	legend location
+		outer;
+		right;
+		offset: 210 @ -200.
+	legend build.
+
+
+	chart xlabel: 'Grow headroom [MB]'.
+	chart ylabel: 'Number of FullGC passes'.
+	chart title: 'FullGC based on Grow headroom creating 100 objects of 24MB each'.
+
+	^ chart
+]
+
+{ #category : #plot }
+GCPMultiChart >> plotScavengeTime [
+
+	| chart legend |
+	chart := RSChart new.
+	legend := RSLegend new.
+
+	profiles associations sorted do: [ :tuple |	| name edenSizesWithFiles data plot |
+		name := tuple key.
+		edenSizesWithFiles := tuple value.
+		data := edenSizesWithFiles sorted asOrderedDictionary collect: [
+			        :file | | trace scavenges total |
+			        trace := self loadGCLogFrom: file.
+			        scavenges := trace select: [ :e |
+				                     e className includesSubstring: 'Scavenge' ].
+			        total := scavenges sum: [ :e | e deltaUsecs ].
+					  total > 300000 ifTrue: [ total // 10 ] ifFalse: [ total ] ].
+
+		chart
+			addPlot: (plot := RSLinePlot new x: data keys y: data values);
+			addPlot: (RSScatterPlot new x: data keys y: data values).
+
+		legend text: name withBoxColor: plot computeColor ].
+
+
+	chart addDecoration: (RSHorizontalTick new
+			 numberOfTicks: 5;
+			 fontSize: 7;
+			 labelConversion: [ :e | e asInteger printString ];
+			 yourself).
+	chart addDecoration: (RSVerticalTick new
+			 numberOfTicks: 5;
+			 fontSize: 7;
+			 labelConversion: [ :e | (e // 1000) printString ];
+			 yourself).
+
+	self addLegend: legend toChart: chart.
+
+	chart xlabel: 'Eden size [MB]'.
+	chart ylabel: 'Total Scavenge time [ms]'.
+	chart title: 'Scavenge time based on Eden size'.
+	^ chart
+]
+
+{ #category : #plot }
+GCPMultiChart >> plotTenuredData [
+
+		| chart legend |
+	chart := RSChart new.
+	legend := RSLegend new.
+
+	profiles associations sorted do: [ :tuple |	| name edenSizesWithFiles data plot |
+		name := tuple key.
+		edenSizesWithFiles := tuple value.
+		data := edenSizesWithFiles sorted asOrderedDictionary collect: [
+			        :file | | trace scavenges total |
+			        trace := self loadGCLogFrom: file.
+			        scavenges := trace select: [ :e |
+				                     e className includesSubstring: 'Scavenge' ].
+			        total := scavenges sum: [ :e | e deltaTenured ].
+			total := total > 200000 ifTrue: [ total // 10 ]  ifFalse: [ total ].
+					  total // 1000 ].
+
+		chart
+			addPlot: (plot := RSLinePlot new x: data keys y: data values);
+			addPlot: (RSScatterPlot new x: data keys y: data values).
+
+		legend text: name withBoxColor: plot computeColor ].
+
+
+	chart addDecoration: (RSHorizontalTick new
+			 numberOfTicks: 5;
+			 fontSize: 7;
+			 labelConversion: [ :e | e asInteger printString ];
+			 yourself).
+	chart addDecoration: (RSVerticalTick new
+			 numberOfTicks: 5;
+			 fontSize: 7;
+			 labelConversion: [ :e | e asInteger printString ];
+			 yourself).
+
+	self addLegend: legend toChart: chart.
+
+	chart xlabel: 'Survivors to keep [thousands of objects]'.
+	chart ylabel: 'Tenured data size [KB]'.
+	chart title: 'Amount of data tenured based on survivors to keep parameter'.
+	^ chart
+]
+
+{ #category : #helper }
+GCPMultiChart >> profilesDo: binaryBlock [
+
+	profiles associations sorted do: [ :tuple |
+		binaryBlock value: tuple key value: tuple value ]
+]

--- a/src/GCProfile/GCPSimpleChart.class.st
+++ b/src/GCProfile/GCPSimpleChart.class.st
@@ -1,0 +1,207 @@
+Class {
+	#name : #GCPSimpleChart,
+	#superclass : #GCChart,
+	#instVars : [
+		'profiles',
+		'showFullGC',
+		'extraMarkers'
+	],
+	#category : #GCProfile
+}
+
+{ #category : #configure }
+GCPSimpleChart >> addExtraMarker: aDecoration [
+
+	extraMarkers add: aDecoration
+]
+
+{ #category : #configure }
+GCPSimpleChart >> addProfile: aFileReference named: name [
+
+	profiles at: name put: aFileReference
+]
+
+{ #category : #initialization }
+GCPSimpleChart >> initialize [
+
+	super initialize.
+	profiles := OrderedDictionary new.
+	extraMarkers := OrderedCollection new.
+	showFullGC := false.
+	
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotFullGC: aFileReference named: name [
+
+	| trace n fullGCs chart plot |
+	trace := self loadGCLogFrom: aFileReference.
+
+	n := 0.
+	fullGCs := trace collect: [ :e |
+		           (e className includesSubstring: 'FullGC') ifTrue: [
+			           n := e fullGCs ].
+		           n ].
+
+
+
+	chart := RSChart new.
+
+	plot := RSLinePlot new
+		        color: Color black;
+		        x: (1 to: fullGCs size) y: fullGCs.
+
+	chart addPlot: plot.
+
+	self addTicks: (5 min: fullGCs max + 1) toChart: chart.
+
+	chart ylabel: 'FullGCs'.
+	chart xlabel: 'Scavenges'.
+	chart title: name.
+
+	chart build.
+
+
+	^ chart canvas
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotFullGCs [
+
+	| plots |
+	plots := profiles associations collect: [ :tuple |
+		         self plotFullGC: tuple value named: tuple key ].
+
+	^ self multiPlotWith: plots
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotGCProfile: aFileReference named: name [
+
+	| trace |
+	trace := self loadGCLogFrom: aFileReference.
+	^ self plotScavenge: { name } , trace
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotGCProfiles [
+
+	| plots |
+	plots := profiles associations collect: [ :tuple |
+		         self plotGCProfile: tuple value named: tuple key ].
+
+	^ self multiPlotWith: plots
+]
+
+{ #category : #'as yet unclassified' }
+GCPSimpleChart >> plotScavenge: trace [
+
+	| chart plot y scavenges fullGCs tenures scavengesAndFullGCs markers |
+	scavengesAndFullGCs := trace allButFirst.
+	scavenges := scavengesAndFullGCs select: [ :e |
+		             e className includesSubstring: 'Scavenge' ].
+	fullGCs := scavengesAndFullGCs select: [ :e |
+		           e className includesSubstring: 'FullGC' ].
+	tenures := scavenges collect: [ :e | e tTenureThreshold // 1000 ].
+
+	y := scavenges collect: [ :e | e eSurvivorBytes // 1000 ].
+
+
+	chart := RSChart new.
+
+	plot := RSLinePlot new
+		        color: Color black;
+		        x: (1 to: scavenges size) y: y.
+
+	chart addPlot: plot.
+
+	tenures doWithIndex: [ :bytes :i |
+		bytes > 0 ifTrue: [
+			chart addPlot: (RSScatterPlot new x: { i } y: { bytes }) ] ].
+
+
+	self addTicks: 8 toChart: chart.
+
+	showFullGC ifTrue: [
+		markers := OrderedCollection new.
+		fullGCs doWithIndex: [ :e :i |
+			| x marker |
+			x := (scavengesAndFullGCs indexOf: e) - i.
+			marker := (RSXMarkerDecoration new atValue: x) color: Color red.
+			markers add: marker.
+			chart addDecoration: marker ] ].
+
+	extraMarkers do: [ :marker | chart addDecoration: marker ].
+
+
+	chart ylabel: 'Survivors [KB]'.
+	chart xlabel: 'Scavenges'.
+	chart title: trace first.
+
+	chart build.
+
+
+	showFullGC ifTrue: [
+		markers allButFirst doWithIndex: [ :m :i |
+			m lines do: [ :line |
+				| label text |
+				text := (fullGCs at: i + 1) fullUsecs - (fullGCs at: i) fullUsecs.
+				label := RSLabel new
+					         text: text // 1000;
+					         color: Color red;
+					         fontSize: 6;
+					         yourself.
+				RSLocation new
+					above;
+					move: label on: line.
+				chart canvas add: label ] ] ].
+
+
+	^ chart canvas
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotScavengeTime: aFileReference named: name [
+
+	| trace scavenges uSecs rememberedSize chart plot |
+	trace := self loadGCLogFrom: aFileReference.
+	scavenges := trace select: [ :e |
+		             e className includesSubstring: 'Scavenge' ].
+	uSecs := scavenges collect: [ :e | e deltaUsecs // 1000 "ms" ].
+	rememberedSize := scavenges collect: [ :e | e eRememberedSetSize ].
+
+
+	chart := RSChart new.
+
+	plot := RSLinePlot new
+		        color: Color black;
+		        x: (1 to: scavenges size) y: uSecs.
+
+	chart addPlot: plot.
+
+	self addTicks: 5 toChart: chart.
+
+	chart ylabel: 'Time [ms]'.
+	chart xlabel: 'Scavenges'.
+	chart title: name.
+
+	chart build.
+
+	^ chart canvas
+]
+
+{ #category : #plot }
+GCPSimpleChart >> plotScavengeTimes [
+
+	| plots |
+	plots := profiles associations collect: [ :tuple |
+		         self plotScavengeTime: tuple value named: tuple key ].
+
+	^ self multiPlotWith: plots
+]
+
+{ #category : #configure }
+GCPSimpleChart >> showFullGC: aBoolean [ 
+
+	showFullGC := aBoolean 
+]

--- a/src/GCProfile/package.st
+++ b/src/GCProfile/package.st
@@ -1,0 +1,1 @@
+Package { #name : #GCProfile }


### PR DESCRIPTION
Here is the code to create many charts of Garbage Collector profile data.
I don't want to lose this code and I think this is the best place to push it.

Some examples (good for documentation):

### Simple charts (based on 1 profile each)

```st
"Instanciate"
chart := GCChart simple.

"Add profile file with a name for each"
chart addProfile: file1 named: 'Before'.
chart addProfile: file2 named: 'After'.

"Configure extra stuff"
chart showFullGC: false.

"Plot!"
chart plotGCProfiles
```

![image](https://github.com/tesonep/benchy/assets/4098184/74911fdf-ab8a-4c83-afa3-cc29339ff536)

You can plot other charts using the same object:

```st
chart plotFullGCs
```

![image](https://github.com/tesonep/benchy/assets/4098184/4237c774-09e6-4f56-8447-b5d35d32bd22)


```st
chart plotScavengeTimes
```

![image](https://github.com/tesonep/benchy/assets/4098184/ef7ac2e5-66af-4995-ab78-4fe5936e4517)




### Multi charts (based on n profiles each)

```st
"Instanciate"
chart := GCChart multi.

"Create a structure with a value for each profile (used on X-axis)"
gcRatioProfiles := { 
  33 -> file1 . 
  250 -> file2 . 
  1000 -> file3 
}.

"Add profile files for each app"
chart addProfile: gcRatioProfiles forApplication: 'App 1'.

"Plot!"
chart plotGCRatio
```

![image](https://github.com/tesonep/benchy/assets/4098184/1dce7faa-9f4a-494e-99e4-2da1f6c8e41d)


You can plot many apps in the same chart

```st
...

"Add profile files for each app"
chart addProfile: opalTenureProfiles forApplication: 'App 1'.
chart addProfile: networkTenureProfiles forApplication: 'App 2'.
chart addProfile: dataFrameTenureProfiles forApplication: 'App 3'.

"Plot!"
chart plotTenuredData.
```

![image](https://github.com/tesonep/benchy/assets/4098184/41d9d5b9-67b3-4e54-b1d9-4955484bce18)


And many charts using the same data

```st
chart multiPlot: { #plotGCPasses . #plotScavengeTime }.
```

![image](https://github.com/tesonep/benchy/assets/4098184/e0e95d3c-cf1d-4a29-bce7-ea587c5aa22d)

