### PR TITLE
Update packages in the baseline.

### DIFF
--- a/src/BaselineOfBenchHistory/BaselineOfBenchHistory.class.st
+++ b/src/BaselineOfBenchHistory/BaselineOfBenchHistory.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #BaselineOfBenchHistory,
-	#superclass : #BaselineOf,
-	#category : #BaselineOfBenchHistory
+	#name : 'BaselineOfBenchHistory',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfBenchHistory',
+	#package : 'BaselineOfBenchHistory'
 }
 
-{ #category : #baselines }
+{ #category : 'baselines' }
 BaselineOfBenchHistory >> baseline: spec [
 	<baseline>
 	spec
@@ -17,7 +18,13 @@ BaselineOfBenchHistory >> baseline: spec [
 					repository: 'github://ObjectProfile/Roassal3';
 					loads: 'Full' ];
 				
-				"Package"
-				package: 'BenchHistory'
-			 ]
+				"Packages"
+				package: 'Benchy' with: [ spec requires: #('NeoCSV' 'Roassal3') ];
+				package: 'Benchy-Tests' with: [ spec requires: #('Benchy') ];
+				package: 'GCProfile' with: [ spec requires: #('Roassal3') ];
+				
+				"Groups"
+				group: 'Tests' with: #('Benchy-Tests' );
+				group: 'All' with: #('Benchy' 'Benchy-Tests' 'GCProfile');
+				group: 'default' with: #('Benchy') ]
 ]

--- a/src/BaselineOfBenchHistory/package.st
+++ b/src/BaselineOfBenchHistory/package.st
@@ -1,1 +1,1 @@
-Package { #name : #BaselineOfBenchHistory }
+Package { #name : 'BaselineOfBenchHistory' }


### PR DESCRIPTION
There were some issues with the Baseline:

- The BaselineOf was pointing to a previous package named "BenchHistory", now we use Benchy and Benchy-Tests.
- The package for tests were not referenced.
- No groups were defined.

This PR update packages in the baseline to load latests changes and add groups.
You can try loading this baseline as follows:

```smalltalk
EpMonitor disableDuring: [ 
	Metacello new
		baseline: 'BenchHistory';
		repository: 'github://tesonep/benchy:update_baseline';
		load ]
```
And the group with everything loaded:

```smalltalk
EpMonitor disableDuring: [ 
	Metacello new
		baseline: 'BenchHistory';
		repository: 'github://tesonep/benchy:update_baseline';
		load: #('All') ]
```
