### PR TITLE
Adding rebench conf(s) with buildVMs and plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 _build
 Rplots.pdf
 .DS_Store
+*.data
+*.log
+*.fuel
+*-Test.xml

--- a/VMs/VMs.inc
+++ b/VMs/VMs.inc
@@ -9,6 +9,8 @@ set -o nounset
 # Set current file directory for relative access
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+source ${__dir}/../"environment.inc"
+
 ARCH=$(uname -m)
 OS=$(uname -s)
 BUILD_VMS_DIR=$2

--- a/VMs/druid.sh
+++ b/VMs/druid.sh
@@ -4,4 +4,4 @@ source "$1/VMs.inc"
 
 updateVMRepo druid
 
-buildVM DruidVM
+buildVM DruidVMFullCompilation

--- a/buildVMs.sh
+++ b/buildVMs.sh
@@ -12,7 +12,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/"environment.inc"
 
 # Delete existing VMs
-delete_vms () {
+delete_vms() {
 	rm -rf $BUILD_VMS_DIR
 }
 
@@ -24,6 +24,7 @@ basename(){
 
 export -f basename
 VMS_NAMES=$(find $VMS_SCRIPT_DIR -iname "*.sh" | xargs -n1 bash -c 'basename -s .sh' )
+VMS_NAMES=${1-$VMS_NAMES}
 
 # Build VMs
 for vm in $VMS_NAMES; do

--- a/environment.inc
+++ b/environment.inc
@@ -6,6 +6,9 @@ set -o pipefail
 set -o nounset
 # set -o xtrace
 
+# Add common application folder to the path
+PATH=/opt/homebrew/bin:$PATH
+
 # Set current file directory for relative access
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/rebench/build_time.conf
+++ b/rebench/build_time.conf
@@ -1,0 +1,68 @@
+runs:
+    invocations: 10
+
+# this run definition will be chosen if no parameters are given to rebench
+default_experiment: all
+default_data_file: 'buildTime.data'
+
+# a set of suites with different benchmarks and possibly different settings
+benchmark_suites:
+    RunDruid:
+        gauge_adapter: Time
+        command: eval "%(benchmark)s"
+        benchmarks:
+            - DRInterpreterToCompiler generateDruidJITModel
+
+    RunSlang:
+        gauge_adapter: Time
+        command: eval "%(benchmark)s"
+        benchmarks:
+            - "PharoVMMaker generate: #JITVM"
+            - "PharoVMMaker generate: #DruidVM"
+            - "PharoVMMaker generate: #JITZeroVM"
+
+    CompileJIT:
+        gauge_adapter: Time
+        location: ../_build/generatedVM
+        build: 
+            - 'HOME="/Users/palumbon" ../VMs/latest10/Pharo.app/Contents/MacOS/Pharo ../images/P11-jit-druid/P11-jit-druid.image eval "PharoVMMaker generate: #JITVM"'
+        command: install > installJIT.log
+        benchmarks:
+            - "JITVM"
+
+    CompileDruid:
+        gauge_adapter: Time
+        location: ../_build/generatedVM
+        build: 
+            - 'HOME="/Users/palumbon" ../VMs/latest10/Pharo.app/Contents/MacOS/Pharo ../images/P11-jit-druid/P11-jit-druid.image eval "PharoVMMaker generate: #DruidVM"'
+        command: install > installDruid.log
+        benchmarks:
+            - "DruidVM"
+
+
+# a set of executables for the benchmark execution
+executors:
+    Latest10:
+        path: ../_build
+        executable: ./VMs/latest10/Pharo.app/Contents/MacOS/Pharo
+        args: ./images/P11-jit-druid/P11-jit-druid.image --no-default-preferences
+
+    Make:
+        executable: make
+
+
+# combining benchmark suites and executions
+experiments:
+    Compile:
+        suites:
+          - CompileJIT
+          - CompileDruid
+        executions:
+          - Make
+
+    Builds:
+        suites:
+          - RunDruid
+          - RunSlang
+        executions:
+          - Latest10

--- a/rebench/compile_count.conf
+++ b/rebench/compile_count.conf
@@ -1,0 +1,213 @@
+# this run definition will be chosen if no parameters are given to rebench
+runs:
+  invocations: 5
+
+default_experiment: DruidPaper
+default_data_file: 'compileCount.data'
+
+# a set of suites with different benchmarks and possibly different settings
+benchmark_suites:
+    Tests: # TODO: Return the compilation count
+        gauge_adapter: Time
+        command: test --junit-xml-output "%(benchmark)s"
+        benchmarks:
+            - "Opal.*"
+            - "Kernel.*"
+            - "File.*"
+    Smark-Richards:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - "SMarkRichards"
+    Smark-DeltaBlue:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - "SMarkDeltaBlue"
+    BenchmarkGameSuite-VeryShort:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 300000.
+    
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+    
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 300000;
+                iterations: 10.
+    
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - benchFasta
+            - benchChameleons
+            - benchReverseComplement
+            - benchThreadRing
+            - benchNBody
+    BenchmarkGameSuite-Short:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 30000.
+            
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+            
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 30000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - benchKNucleotide
+            - benchChameneosRedux
+            - benchRegexDNA
+    BenchmarkGameSuite-Mid:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1500.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1500;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - benchPiDigits
+    BenchmarkGameSuite-Long:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1000.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1000;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - benchSpectralNorm
+            - benchMeteor
+            - benchMandelbrot
+    BenchmarkGameSuite-VeryLong:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 15;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm compiledMethodsCount + Smalltalk vm compiledBlocksCount"
+        benchmarks:
+            - benchBinaryTrees
+#            - benchFannkuchRedux
+
+# a set of executables for the benchmark execution
+executors:
+    Latest10:
+        path: ../_build
+        executable: ./VMs/latest10/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid:
+        path: ../_build
+        executable: ./VMs/druid/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Stack:
+        path: ../_build
+        executable: ./VMs/stack/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Zero:
+        path: ../_build
+        executable: ./VMs/zero/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Mixed:
+        path: ../_build
+        executable: ./VMs/mixed/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidPartial:
+        path: ../_build
+        executable: ./VMs/druidPartialCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidFull:
+        path: ../_build
+        executable: ./VMs/druidFullCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+
+
+# combining benchmark suites and executions
+experiments:
+    DruidPaper:
+        suites:
+        #   - Tests
+          - Smark-Richards
+          - Smark-DeltaBlue
+          - BenchmarkGameSuite-VeryLong
+          - BenchmarkGameSuite-Long
+          - BenchmarkGameSuite-Mid
+          - BenchmarkGameSuite-Short
+          - BenchmarkGameSuite-VeryShort
+        executions:
+            - Latest10
+            - Druid
+            # - Stack
+            - Zero
+            - DruidPartial
+            - DruidFull
+            # - Mixed

--- a/rebench/compile_time.conf
+++ b/rebench/compile_time.conf
@@ -1,0 +1,213 @@
+# this run definition will be chosen if no parameters are given to rebench
+runs:
+  invocations: 5
+
+default_experiment: DruidPaper
+default_data_file: 'compileTime.data'
+
+# a set of suites with different benchmarks and possibly different settings
+benchmark_suites:
+    Tests: # TODO: Return the compilation time
+        gauge_adapter: Time
+        command: test --junit-xml-output "%(benchmark)s"
+        benchmarks:
+            - "Opal.*"
+            - "Kernel.*"
+            - "File.*"
+    Smark-Richards:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - "SMarkRichards"
+    Smark-DeltaBlue:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - "SMarkDeltaBlue"
+    BenchmarkGameSuite-VeryShort:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 300000.
+    
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+    
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 300000;
+                iterations: 10.
+    
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - benchFasta
+            - benchChameleons
+            - benchReverseComplement
+            - benchThreadRing
+            - benchNBody
+    BenchmarkGameSuite-Short:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 30000.
+            
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+            
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 30000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - benchKNucleotide
+            - benchChameneosRedux
+            - benchRegexDNA
+    BenchmarkGameSuite-Mid:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1500.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1500;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - benchPiDigits
+    BenchmarkGameSuite-Long:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1000.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1000;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - benchSpectralNorm
+            - benchMeteor
+            - benchMandelbrot
+    BenchmarkGameSuite-VeryLong:
+        gauge_adapter: PlainSecondsLog
+        command: |-
+            eval "
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 15;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner.
+            Smalltalk vm totalJITCompileTime"
+        benchmarks:
+            - benchBinaryTrees
+#            - benchFannkuchRedux
+
+# a set of executables for the benchmark execution
+executors:
+    Latest10:
+        path: ../_build
+        executable: ./VMs/latest10/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid:
+        path: ../_build
+        executable: ./VMs/druid/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Stack:
+        path: ../_build
+        executable: ./VMs/stack/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Zero:
+        path: ../_build
+        executable: ./VMs/zero/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Mixed:
+        path: ../_build
+        executable: ./VMs/mixed/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidPartial:
+        path: ../_build
+        executable: ./VMs/druidPartialCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidFull:
+        path: ../_build
+        executable: ./VMs/druidFullCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+
+
+# combining benchmark suites and executions
+experiments:
+    DruidPaper:
+        suites:
+        #   - Tests
+          - Smark-Richards
+          - Smark-DeltaBlue
+          - BenchmarkGameSuite-VeryLong
+          - BenchmarkGameSuite-Long
+          - BenchmarkGameSuite-Mid
+          - BenchmarkGameSuite-Short
+          - BenchmarkGameSuite-VeryShort
+        executions:
+            - Latest10
+            - Druid
+            # - Stack
+            - Zero
+            - DruidPartial
+            - DruidFull
+            # - Mixed

--- a/rebench/execution_time.conf
+++ b/rebench/execution_time.conf
@@ -1,0 +1,278 @@
+# this run definition will be chosen if no parameters are given to rebench
+runs:
+  invocations: 5
+
+default_experiment: DruidPaper
+default_data_file: 'executionTime.data'
+
+# a set of suites with different benchmarks and possibly different settings
+benchmark_suites:
+    Tests:
+        gauge_adapter: Time
+        command: test --junit-xml-output "%(benchmark)s"
+        benchmarks:
+            - "Opal.*"
+            - "Kernel.*"
+            - "File.*"
+    Smark-Richards:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - "SMarkRichards"
+    Smark-DeltaBlue:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "benchmark := %(benchmark)s new.
+            runner := benchmark class defaultRunner new.
+            runner
+                problemSize: 20000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - "SMarkDeltaBlue"
+    BenchmarkGameSuite-VeryShort:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 300000.
+    
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+    
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 300000;
+                iterations: 10.
+    
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - benchFasta
+            - benchChameleons
+            - benchReverseComplement
+            - benchThreadRing
+            - benchNBody
+    BenchmarkGameSuite-Short:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 30000.
+            
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+            
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 30000;
+                iterations: 10.
+            
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - benchKNucleotide
+            - benchChameneosRedux
+            - benchRegexDNA
+    BenchmarkGameSuite-Mid:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1500.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1500;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - benchPiDigits
+    BenchmarkGameSuite-Long:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "
+            BGFastaCache primeForFasta: 1000.
+
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 1000;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - benchSpectralNorm
+            - benchMeteor
+            - benchMandelbrot
+    BenchmarkGameSuite-VeryLong:
+        gauge_adapter: ReBenchLog
+        command: |-
+            eval "
+            benchmark := BenchmarkGameSuite new.
+            runner := benchmark class defaultRunner new.
+
+            benchmark runOnly: #%(benchmark)s.
+            runner
+                problemSize: 15;
+                iterations: 10.
+
+            benchmark runner: runner.
+            runner suite: benchmark.
+            runner execute.
+            runner"
+        benchmarks:
+            - benchBinaryTrees
+#            - benchFannkuchRedux
+
+# a set of executables for the benchmark execution
+executors:
+    Latest10:
+        build: 
+            - ./buildVMs.sh latest10
+        path: ../
+        executable: ./_build/VMs/latest10/Pharo.app/Contents/MacOS/Pharo
+        args: ./_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Latest10Base:
+        path: ../
+        executable: ./_build/VMs/latest10Base/Pharo.app/Contents/MacOS/Pharo
+        args: ./_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid:
+        build: 
+            - ./buildVMs.sh druid
+        path: ../
+        executable: ./_build/VMs/druid/Pharo.app/Contents/MacOS/Pharo
+        args: ./_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Stack:
+        build: 
+            - ./buildVMs.sh stack
+        path: ../
+        executable: ./_build/VMs/stack/Pharo.app/Contents/MacOS/Pharo
+        args: ./_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Zero:
+        path: ../_build
+        executable: ./VMs/zero/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Mixed:
+        path: ../_build
+        executable: ./VMs/mixed/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidPartial:
+        path: ../_build
+        executable: ./VMs/druidPartialCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidFull:
+        path: ../_build
+        executable: ./VMs/druidFullCompilation/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidBase:
+        path: ../_build
+        executable: ./VMs/druidBaseNew/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    DruidCopy:
+        path: ../_build
+        executable: ./VMs/druidCopy/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid-3b83cab5:
+        path: ../_build
+        executable: ./VMs/search/druid-vm-3b83cab5/build/dist/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid-7a6becf7c:
+        path: ../_build
+        executable: ./VMs/search/druid-vm-7a6becf7c/build/dist/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid-6ba9d9817:
+        path: ../_build
+        executable: ./VMs/search/druid-vm-6ba9d9817/build/dist/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid-4d9460d87:
+        path: ../_build
+        executable: ./VMs/search/druid-vm-4d9460d87/build/dist/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+    Druid-e07db42fb:
+        path: ../_build
+        executable: ./VMs/search/druid-vm-e07db42fb/build/dist/Pharo.app/Contents/MacOS/Pharo
+        args: ../_build/images/Pharo11SMark/Pharo11SMark.image --no-default-preferences
+
+
+# combining benchmark suites and executions
+experiments:
+    Guille:
+        suites:
+          - Tests
+          - Smark-Richards
+          - Smark-DeltaBlue
+          - BenchmarkGameSuite-VeryLong
+          - BenchmarkGameSuite-Long
+          - BenchmarkGameSuite-Mid
+          - BenchmarkGameSuite-Short
+          - BenchmarkGameSuite-VeryShort
+        executions:
+            - Pharo-10.0.4
+            - Pharo-10.0.7
+            - Pharo-10.0.7-fix
+
+    DruidPaper:
+        suites:
+          - Tests
+          - Smark-Richards
+          - Smark-DeltaBlue
+          - BenchmarkGameSuite-VeryLong
+          - BenchmarkGameSuite-Long
+          - BenchmarkGameSuite-Mid
+          - BenchmarkGameSuite-Short
+          - BenchmarkGameSuite-VeryShort
+        executions:
+            - Latest10
+            - Druid
+            - Stack
+            # - Zero
+            # - DruidPartial
+            # - DruidFull
+            # - Mixed
+    
+    Test:
+        suites:
+          - BenchmarkGameSuite-Short
+        executions:
+            - Latest10
+            - Latest10Base
+            - Druid
+            - Stack
+            - DruidPartial
+            - DruidFull
+            - Zero
+            - DruidBase
+            - DruidCopy
+            - Druid-3b83cab5
+            - Druid-7a6becf7c
+            - Druid-6ba9d9817
+            - Druid-4d9460d87
+            - Druid-e07db42fb

--- a/rebench/poc.conf
+++ b/rebench/poc.conf
@@ -1,0 +1,48 @@
+runs:
+    invocations: 7
+
+# this run definition will be chosen if no parameters are given to rebench
+default_experiment: all
+default_data_file: 'example.data'
+
+# a set of suites with different benchmarks and possibly different settings
+benchmark_suites:
+    PharoTests:
+        gauge_adapter: Time
+        command: test --junit-xml-output "%(benchmark)s"
+        benchmarks:
+            - "Files-.*"
+            - "Opal.*"
+
+    PharoCompilationTimes:
+        gauge_adapter: PlainSecondsLog
+        command: eval %(benchmark)s. Smalltalk vm totalJITCompileTime
+        benchmarks:
+            - "1+1"
+
+
+# a set of executables for the benchmark execution
+executors:
+    Druid:
+        path: .
+        executable: ../_build/VMs/druid/Pharo.app/Contents/MacOS/Pharo ../_build/images/Pharo10/Pharo10.image --no-default-preferences
+    Latest10:
+        path: .
+        executable: ../_build/VMs/latest10/Pharo.app/Contents/MacOS/Pharo ../_build/images/Pharo10/Pharo10.image --no-default-preferences
+
+
+
+# combining benchmark suites and executions
+experiments:
+    Tests:
+        suites:
+          - PharoTests
+        executions:
+          - Druid
+          - Latest10
+    Compilations:
+        suites:
+          - PharoCompilationTimes
+        executions:
+          - Druid
+          - Latest10

--- a/src/Rebench-Charts/RebenchResultCharts.class.st
+++ b/src/Rebench-Charts/RebenchResultCharts.class.st
@@ -1,0 +1,221 @@
+Class {
+	#name : #RebenchResultCharts,
+	#superclass : #Object,
+	#instVars : [
+		'data'
+	],
+	#category : #'Rebench-Charts'
+}
+
+{ #category : #statistics }
+RebenchResultCharts class >> means: aFileReference [
+
+	^ self new
+		  parseData: aFileReference;
+		  means
+]
+
+{ #category : #plot }
+RebenchResultCharts class >> plotBuildTime: aFileReference [
+
+	^ self new
+		  parseData: aFileReference;
+		  plotBuildTime
+]
+
+{ #category : #plot }
+RebenchResultCharts class >> plotExecutionTime: aFileReference [
+
+	^ self new
+		  parseData: aFileReference;
+		  plotExecutionTime
+		
+]
+
+{ #category : #'as yet unclassified' }
+RebenchResultCharts >> averageFor: aKey [
+
+	^ (data at: aKey) average
+]
+
+{ #category : #data }
+RebenchResultCharts >> means [
+	self shouldBeImplemented.
+]
+
+{ #category : #'as yet unclassified' }
+RebenchResultCharts >> parseData: dataFile [
+
+	| headerLines rawData preproccessed |
+	headerLines := dataFile contents lines count: [ :l |
+		               l beginsWith: '#' ].
+	rawData := (NeoCSVReader on: dataFile readStream)
+		           skip: headerLines;
+		           separator: Character tab;
+		           recordClass: Dictionary;
+		           readHeader;
+		           addIntegerFieldAt: 'invocation';
+		           addIntegerFieldAt: 'iteration';
+		           addFloatFieldAt: 'time';
+		           addFieldAt: 'unit';
+		           addFieldAt: 'user';
+		           addFieldAt: 'bench';
+		           addFieldAt: 'vm';
+		           addFieldAt: 'suite';
+		           "addFloatField;""collect: #first."upToEnd.
+
+
+
+
+
+	preproccessed := (rawData
+		                  select: [ :d | (d at: #user) = 'total' ]
+		                  thenCollect: [ :d |
+			                  ('-' join: {
+					                   (d at: #suite).
+					                   (d at: #bench).
+					                   (d at: #vm) }) -> (d at: #time) ]) sorted.
+
+
+	data := (preproccessed groupedBy: #key) collect: [ :col |
+		        col collect: #value ].
+	^ data
+]
+
+{ #category : #plots }
+RebenchResultCharts >> plotBuildTime [
+
+	| c druidBuildTime preBuildTimes druidSlangTime jitSlangTime slangTimes druidCompileTime jitCompileTime compileTimes legend |
+	druidBuildTime := self averageFor:
+		                  'RunDruid-DRInterpreterToCompiler generateDruidJITModel-Latest10'.
+
+	preBuildTimes := {
+		                 druidBuildTime.
+		                 0 "Handwritten version has not pre-pass" }.
+
+
+	druidSlangTime := (data at:
+		                   'RunSlang-PharoVMMaker generate: #DruidVM-Latest10')
+		                  average.
+	jitSlangTime := (data at:
+		                 'RunSlang-PharoVMMaker generate: #JITVM-Latest10')
+		                average.
+
+	slangTimes := {
+		              druidSlangTime.
+		              jitSlangTime }.
+
+
+	druidCompileTime := (data at: 'CompileDruid-DruidVM-Make') average.
+
+	jitCompileTime := (data at: 'CompileJIT-JITVM-Make') average.
+
+	compileTimes := {
+		                druidCompileTime.
+		                jitCompileTime }.
+
+
+
+
+	c := RSCompositeChart new.
+	c ylabel: 'Time [sec]'.
+	c add: (RSAbstractChart barHeights: preBuildTimes).
+	c add:
+		((RSAbstractChart barHeights: slangTimes) bottom: preBuildTimes).
+	c add:
+		((RSAbstractChart barHeights: compileTimes) bottom: slangTimes).
+	c horizontalTick fromNames: #( DruidVM HandwrittenVM ).
+	c verticalTick
+		numberOfTicks: 10;
+		useNiceLabel;
+		labelConversion: [ :ms | ms // 1000 ].
+	c build.
+
+	legend := RSLegend new.
+	#( Druid Slang GCC ) doWithIndex: [ :lbl :index |
+		legend text: lbl withBoxColor: (c plots at: index) computeColor ].
+	legend container: c canvas.
+	legend location
+		outer;
+		top;
+		right;
+		offset: 20 @ 60.
+
+	legend build.
+	^ c canvas
+]
+
+{ #category : #'as yet unclassified' }
+RebenchResultCharts >> plotExecutionTime [
+
+	| relative canvas colors legend targetVMs dataToPlot |
+	targetVMs := #( Druid DruidFull DruidPartial Stack ).
+
+	relative := OrderedDictionary new.
+	dataToPlot := data associations select: [ :e |
+		              targetVMs includes: ('-' split: e key) last ].
+
+	dataToPlot foursDo: [ :druid :druidFull :druidPartial :stack |
+		relative at: druid key put: stack value / druid value.
+		relative at: druidFull key put: stack value / druidFull value.
+		relative at: druidPartial key put: stack value / druidPartial value.
+		relative at: stack key put: stack value / stack value average ].
+
+
+
+	"	data associations foursDo: [ :druid :latest :stack :zero |
+		relative at: stack key put: stack value / stack value average.
+		relative at: latest key put: stack value / latest value.
+		relative at: druid key put: stack value / druid value ].
+"
+
+	canvas := RSCanvas new.
+	"	canvas title: 'Speedup relative to only interpreted VM (higher is better)'."
+
+	"	relative associations legsDo: [ :stack :latest :druid |
+		| benchChart |
+		benchChart := (RSBoxPlot data: stack value)
+		              + (RSBoxPlot data: latest value)
+		              + (RSBoxPlot data: druid value).
+		benchChart horizontalTick fromNames:
+			{ (stack key copyReplaceAll: '-Stack' with: '') }.
+		benchChart addDecoration: (RSYMarkerDecoration new value: 1).
+		colors := benchChart plots collect: #computeColor.
+		canvas add: benchChart asShape ].
+"
+	relative associations foursDo: [ :druid :druidFull :druidPartial :stack |
+		| benchChart |
+		benchChart := (RSBoxPlot data: stack value)
+		              + (RSBoxPlot data: druid value)
+		              + (RSBoxPlot data: druidPartial value)
+		              + (RSBoxPlot data: druidFull value).
+		benchChart horizontalTick fromNames:
+			{ (stack key copyReplaceAll: '-Stack' with: '') }.
+		benchChart addDecoration: (RSYMarkerDecoration new value: 1).
+		colors := benchChart plots collect: #computeColor.
+		canvas add: benchChart asShape ].
+
+
+
+	(RSGridLayout withGap: 25) on: canvas shapes.
+	canvas @ RSCanvasController.
+
+
+	legend := RSLegend new.
+	#( Stack DruidOld DruidPartial DruidFull ) doWithIndex: [ :lbl :index |
+		legend text: lbl withBoxColor: (colors at: index) ].
+	legend container: canvas.
+	legend legendDo: [ :shape |
+		shape
+			withBorder;
+			padding: 10;
+			scaleBy: 2.5 ].
+	legend location
+		outer;
+		top;
+		right;
+		offset: 20 @ 180.
+	legend build.
+
+	^ canvas
+]

--- a/src/Rebench-Charts/SequenceableCollection.extension.st
+++ b/src/Rebench-Charts/SequenceableCollection.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #SequenceableCollection }
+
+{ #category : #'*Rebench-Charts' }
+SequenceableCollection >> foursDo: aBlock [
+	"See #pairsDo: method"
+	
+	1 to: self size // 4 do: [ :index | aBlock value: (self at: 4 * index - 3) value: (self at: 4 * index - 2) value: (self at: 4 * index - 1) value: (self at: 4 * index) ]
+]
+
+{ #category : #'*Rebench-Charts' }
+SequenceableCollection >> legsDo: aBlock [
+	"See #pairsDo: method"
+	
+	1 to: self size // 3 do: [ :index | aBlock value: (self at: 3 * index - 2) value: (self at: 3 * index - 1) value: (self at: 3 * index) ]
+]

--- a/src/Rebench-Charts/package.st
+++ b/src/Rebench-Charts/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Rebench-Charts' }


### PR DESCRIPTION
Adding configuration files to run using [Rebench](https://rebench.readthedocs.io/en/latest/config/)

- `poc.conf` just a Proof Of Concept
- `build_time.conf` measures the Slang code generation and GCC compiler time.
- `compile_count.conf` takes, for each benchmark, the number of compiled methods (and blocks)
- `compile_time.conf` takes, for each benchmark, the time in the JIT compiler
- `execution_time.conf` takes, for each benchmark, the execution time

#### Things to improve
- [ ] The **last three configurations are very similar but I could not reuse them**. The programs that I want to execute is the same, what change is the data that we want to measure at the end.
- [ ] Because of this duplication, changes could be hard to perform. Now I see that the execution config is the only one with the [build VM script](https://github.com/tesonep/benchy/pull/38/files#diff-5b0de7f37b049a18f806a542a877fdbb506ce53b5bc8e1e61156fa77ae1cea86R156-R178) (using Benchy scripts). **We should copy-paste that in the others**.